### PR TITLE
Sketch convert readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,16 @@
-Curie Open Development Kit (CODK) Requirements
---------------
-- 64-bit Linux distribution
+CODK-A applications are developed in C/C++. You can import a sketch (.ino)
+file to use with CODK-A, but you must first convert it to a valid .cpp
+file:
 
-(Tested on Debian 8, Debian 7, Ubuntu 14.04)
-(NOTE: add more distros if anyone's tested on something else)
+  $ make convert-sketch SKETCH=sketch.ino
 
-CODK-A first-time setup
------------------------
+Using the included Blink.ino example sketch, the precedure for converting,
+building and uploading an existing sketch follows (ensure that your
+Arduino 101 board is connected to your PC, and that you know the serial
+device name e.g. "/dev/ttyACM0"):
 
-  Install the Repo tool;
-
-  Make sure you have a '~/bin' directory and that it is included in your path:
-
-    $ mkdir ~/bin
-    $ export PATH=~/bin:$PATH
-
-  Download the Repo tool and ensure that it is executable:
-
-    $ curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-    $ chmod a+x ~/bin/repo
-
-  Install CODK-A-Manifest
-
-    $ mkdir ~/CODK-A
-    $ cd ~/CODK-A
-    $ repo init -u https://github.com/01org/CODK-A-Manifest.git
-    $ repo sync -j4
-
-  Set CODK_DIR
-
-    $ export CODK_DIR=~/CODK-A
-
-    (put this in your ~/.bashrc or whatever)
-    
-  Set up CODK-A-Software
-
-    $ sudo make install-dep -C $CODK_DIR/software
-    $ make setup -C $CODK_DIR/software
-    
-  Set up CODK-A Firmware
-
-    $ cd $CODK_DIR
-    $ sudo make -C $CODK_DIR/arduino101_firmware/projects/arduino101 one_time_setup
-
-CODK-A Software
----------------
-
-  Using CODK-A-Software
-
-  CODK-A applications are developed in C/C++. You can import a sketch (.ino)
-  file to use with CODK-A, but you must first convert it to a valid .cpp
-  file:
-
-    $ make convert-sketch SKETCH=sketch.ino
-
-  Using the included Blink.ino example sketch, the precedure for converting,
-  building and uploading an existing sketch follows (ensure that your
-  Arduino 101 board is connected to your PC, and that you know the serial
-  device name e.g. "/dev/ttyACM0"):
-
-    $ cd $CODK_DIR/software/examples/Blink
-    $ make convert-sketch SKETCH=Blink.ino
-    $ make compile
-    $ make upload SERIAL_PORT=/dev/ttyACM0
-
-
-CODK-A Firmware 
----------------
-
-Build CODK-A Firmware
-
-    $ make -C $CODK_DIR/arduino101_firmware/projects/arduino101 setup image
-
-Flash CODK-A Firmware
-
-    $ cd $CODK_DIR/arduino101_flashpack
-    $ ./create_flasher.sh
-    $ ./flash_dfu.sh
+  Make sure CODK_DIR variable is set to the CODK top-level path
+  $ cd software/examples/Blink
+  $ make convert-sketch SKETCH=Blink.ino
+  $ make compile
+  $ make upload SERIAL_PORT=/dev/ttyACM0

--- a/examples/Blink/Blink.ino
+++ b/examples/Blink/Blink.ino
@@ -13,10 +13,8 @@
   by Scott Fitzgerald
  */
 
-// the setup function runs once when you press reset or power the board
-void setup();
-void loop();
 
+// the setup function runs once when you press reset or power the board
 void setup() {
   // initialize digital pin 13 as an output.
   pinMode(13, OUTPUT);
@@ -29,4 +27,3 @@ void loop() {
   digitalWrite(13, LOW);    // turn the LED off by making the voltage LOW
   delay(1000);              // wait for a second
 }
-

--- a/examples/Blink/Blink.ino.cpp
+++ b/examples/Blink/Blink.ino.cpp
@@ -16,9 +16,6 @@
 #include <Arduino.h>
 
 // the setup function runs once when you press reset or power the board
-void setup();
-void loop();
-
 void setup() {
   // initialize digital pin 13 as an output.
   pinMode(13, OUTPUT);
@@ -31,4 +28,3 @@ void loop() {
   digitalWrite(13, LOW);    // turn the LED off by making the voltage LOW
   delay(1000);              // wait for a second
 }
-


### PR DESCRIPTION
Updated the README since install and usage steps are covered in parent README. Verified the sketch convert steps - which required a rename of the Blink sketch file to work.